### PR TITLE
Unlock log file while running

### DIFF
--- a/gerrit_service.cpp
+++ b/gerrit_service.cpp
@@ -74,14 +74,15 @@ timestamp()
 }
 
 void
-open_logfile()
+open_logfile(bool log_started)
 {
     std::wstring lpath = g_gerrit_site;
     lpath += L"\\logs\\gerrit_service_log";
 
     logfile.open(lpath.c_str(), std::ios_base::app);
 
-    logfile << timestamp() << L" Logging started" << std::endl;
+    if (log_started)
+        logfile << timestamp() << L" Logging started" << std::endl;
 }
 
 void
@@ -357,11 +358,14 @@ run_gerrit()
         ULONG_PTR key = 0;
         LPOVERLAPPED po = NULL;
 
+        logfile.close();
         if (!GetQueuedCompletionStatus(g_completion_port, &n, &key, &po, INFINITE) &&
             po == NULL) {
             process_running = false;
+            open_logfile(false);
             break;
         }
+        open_logfile(false);
 
         if (n == JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO) {
             logfile << timestamp()
@@ -389,7 +393,7 @@ run_gerrit()
 VOID WINAPI
 gerrit_svc_main(__in  DWORD dwArgc, __in  LPTSTR* lpszArgv)
 {
-    open_logfile();
+    open_logfile(true);
 
     logfile << timestamp() << " Starting service" << std::endl;
 


### PR DESCRIPTION
Should prevent the following messages:
[2013-01-27 15:37:34,591] ERROR com.google.gerrit.pgm.util.LogFileCompressor : Cannot compress C:\Projects\gerrit\logs\gerrit_service_log
java.io.IOException: Cannot rename C:\Projects\gerrit\logs.tmp.gerrit_service_log to C:\Projects\gerrit\logs\gerrit_service_log.gz
    at com.google.gerrit.pgm.util.LogFileCompressor.compress(LogFileCompressor.java:139)
    at com.google.gerrit.pgm.util.LogFileCompressor.run(LogFileCompressor.java:92)
    at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
    at java.util.concurrent.FutureTask$Sync.innerRunAndReset(Unknown Source)
    at java.util.concurrent.FutureTask.runAndReset(Unknown Source)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(Unknown Source)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
    at com.google.gerrit.server.git.WorkQueue$Task.run(WorkQueue.java:337)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
    at java.lang.Thread.run(Unknown Source)
